### PR TITLE
Support all-day VEVENT date values

### DIFF
--- a/src/datetime.cpp
+++ b/src/datetime.cpp
@@ -40,8 +40,25 @@ namespace uICAL {
     }
 
     void DateTime::construct(const string& datetime, const TZMap_ptr& tzmap) {
-        if (datetime.length() < 15)
-            throw ValueError(string("Bad datetime: \"") + datetime + "\"");
+        const bool hasTime = datetime.length() >= 15 && datetime.substr(8, 1) == "T";
+
+        if (!hasTime) {
+            if (datetime.length() < 8 || datetime.find('T') != string::npos) {
+                throw ValueError(string("Bad datetime: \"") + datetime + "\"");
+            }
+
+            DateStamp ds(datetime.substr(0, 8) + "T000000");
+
+            if (datetime.length() > 8) {
+                this->tz = new_ptr<TZ>(datetime.substr(8), tzmap);
+            }
+            else {
+                this->tz = TZ::unaware();
+            }
+
+            this->construct(ds, tz);
+            return;
+        }
 
         DateStamp ds(datetime.substr(0, 15));
 

--- a/src/datetime.cpp
+++ b/src/datetime.cpp
@@ -43,7 +43,7 @@ namespace uICAL {
         const bool hasTime = datetime.length() >= 15 && datetime.substr(8, 1) == "T";
 
         if (!hasTime) {
-            if (datetime.length() < 8 || datetime.find('T') != string::npos) {
+            if (datetime.length() < 8 || datetime.find("T") != string::npos) {
                 throw ValueError(string("Bad datetime: \"") + datetime + "\"");
             }
 

--- a/src/vevent.cpp
+++ b/src/vevent.cpp
@@ -18,8 +18,23 @@ namespace uICAL {
         VLine_ptr rRule = obj->getPropertyByName("RRULE");
         VLine_ptr summary = obj->getPropertyByName("SUMMARY");
 
-        this->start = DateTime(dtStart->value + dtStart->getParam("TZID"), tzmap);
-        this->end = DateTime(dtEnd->value + dtStart->getParam("TZID"), tzmap);
+        string dtStartValue = dtStart->value;
+        if (dtStart->getParam("VALUE") == "DATE") {
+            dtStartValue += "T000000";
+        }
+        string dtStartTz = dtStart->getParam("TZID");
+
+        string dtEndValue = dtEnd->value;
+        if (dtEnd->getParam("VALUE") == "DATE") {
+            dtEndValue += "T000000";
+        }
+        string dtEndTz = dtEnd->getParam("TZID");
+        if (dtEndTz.empty()) {
+            dtEndTz = dtStartTz;
+        }
+
+        this->start = DateTime(dtStartValue + dtStartTz, tzmap);
+        this->end = DateTime(dtEndValue + dtEndTz, tzmap);
 
         this->summary = summary->value;
 

--- a/src/vevent.cpp
+++ b/src/vevent.cpp
@@ -2,7 +2,6 @@
 # Copyright (c) 2020 Source Simian  :  https://github.com/sourcesimian/uICAL #
 ############################################################################*/
 #include "uICAL/cppstl.h"
-#include <cctype>
 #include "uICAL/types.h"
 #include "uICAL/util.h"
 #include "uICAL/datetime.h"
@@ -19,59 +18,8 @@ namespace uICAL {
         VLine_ptr rRule = obj->getPropertyByName("RRULE");
         VLine_ptr summary = obj->getPropertyByName("SUMMARY");
 
-        auto isDateOnly = [](const VLine_ptr& line) {
-            if (line == nullptr) {
-                return false;
-            }
-
-            string valueParam = line->getParam("VALUE");
-            if (!valueParam.empty()) {
-                string upper = valueParam;
-                std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char ch) {
-                    return (char)std::toupper(ch);
-                });
-                if (upper == "DATE") {
-                    return true;
-                }
-            }
-
-            const string& value = line->value;
-            return value.find("T") == string::npos && value.length() == 8;
-        };
-
-        auto buildDateTimeValue = [&](const VLine_ptr& line, const string& fallbackTz) {
-            if (line == nullptr) {
-                return string::none();
-            }
-
-            string value = line->value;
-            if (isDateOnly(line) && value.length() == 8) {
-                value += "T000000";
-            }
-
-            string tz = line->getParam("TZID");
-            if (tz.empty()) {
-                tz = fallbackTz;
-            }
-
-            if (!tz.empty()) {
-                value += tz;
-            }
-
-            return value;
-        };
-
-        string dtStartValue = buildDateTimeValue(dtStart, string());
-        string dtStartTz = dtStart != nullptr ? dtStart->getParam("TZID") : string();
-        string dtEndValue = buildDateTimeValue(dtEnd, dtStartTz);
-
-        this->start = DateTime(dtStartValue, tzmap);
-        if (!dtEndValue.empty()) {
-            this->end = DateTime(dtEndValue, tzmap);
-        }
-        else {
-            this->end = this->start;
-        }
+        this->start = DateTime(dtStart->value + dtStart->getParam("TZID"), tzmap);
+        this->end = DateTime(dtEnd->value + dtStart->getParam("TZID"), tzmap);
 
         this->summary = summary->value;
 


### PR DESCRIPTION
## Summary
- normalize DTSTART/DTEND properties declared with VALUE=DATE to midnight timestamps so all-day events parse
- reuse the DTSTART timezone when DTEND omits TZID to preserve previous behaviour

## Testing
- make test-cpp

------
https://chatgpt.com/codex/tasks/task_e_68cc4426d03c832c95df8855dfa7ac80